### PR TITLE
ci(deploy): ensure .ssh directory exists before deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
             PROJECT_DIR: ${{ secrets.PROJECT_DIR }}
         run: |
           # Setup SSH connection
+          mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > private_key && chmod 600 private_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
The ~/.ssh directory is required for SSH operations during deployment. This change creates the directory if it doesn't exist to prevent potential deployment failures due to missing directory structure.