### PR TITLE
ci(deploy): fix docker image path in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
             set -e
             cd $PROJECT_DIR
             echo "--- Loading Docker image ---"
-            docker load -i image.tar
+            docker load -i $PROJECT_DIR/image.tar
 
             echo "--- Stopping existing container (if running) ---"
             docker rm -f worklenz-nginx || true


### PR DESCRIPTION
The image path was hardcoded which could cause issues when loading the Docker image. Updated to use the PROJECT_DIR variable for consistency with the working directory context.