### PR TITLE
ci(deploy): fix docker image path in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,11 +51,11 @@ jobs:
           PROJECT_DIR: ${{ secrets.PROJECT_DIR }}
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key && chmod 600 private_key
-          ssh -i private_key -o StrictHostKeyChecking=no ${SSH_USER}@${SSH_HOST} << 'EOF'
+          ssh -i private_key -o StrictHostKeyChecking=no ${SSH_USER}@${SSH_HOST} << EOF
             set -e
             cd $PROJECT_DIR
             echo "--- Loading Docker image ---"
-            docker load -i $PROJECT_DIR/image.tar
+            docker load -i image.tar
 
             echo "--- Stopping existing container (if running) ---"
             docker rm -f worklenz-nginx || true


### PR DESCRIPTION
The deployment script was incorrectly referencing the image path with $PROJECT_DIR prefix, which caused the docker load command to fail. Remove the prefix to use the correct path where the image is located.