### PR TITLE
ci: update deployment workflow to use Docker and add docker-compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,29 +1,37 @@
-name: Deploy to Server
-# Trigger the workflow on push events to the main branch
+name: Docker Deploy to Docker Hub
+
 on:
   push:
     branches:
       - main
 
+env:
+  IMAGE_NAME: kithceydigital/worklenz-astro
+  IMAGE_TAG: latest
+
 jobs:
-  deploy:
-    name: Deploy
+  build-and-push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup SSH and Deploy
-        env:
-            SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-            SSH_HOST: ${{ secrets.SSH_HOST }}
-            SSH_USER: ${{ secrets.SSH_USER }}
-            PROJECT_DIR: ${{ secrets.PROJECT_DIR }}
-        run: |
-          # Setup SSH connection
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > private_key && chmod 600 private_key
-          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+      - name: Setup Node.js and Install Deps
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-          # Execute the deployment script on the remote server
-          ssh -i private_key ${SSH_USER}@${SSH_HOST} "set -e; echo '--- Starting deployment on server ---'; cd '${PROJECT_DIR}'; echo '--- Pulling latest code from main branch ---'; git pull origin main; echo '--- Installing dependencies with pnpm ---'; pnpm install --frozen-lockfile; echo '--- Building static files ---'; pnpm run build; echo '--- Deployment finished successfully ---'"
+      - run: |
+          corepack enable
+          pnpm install
+          pnpm run build
+
+      - name: Build Docker Image
+        run: |
+          docker build -t $IMAGE_NAME:$IMAGE_TAG .
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Push Docker Image
+        run: docker push $IMAGE_NAME:$IMAGE_TAG

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  worklenz-static-site:
+    image: kithceydigital/worklenz-astro:latest
+    container_name: worklenz-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 30


### PR DESCRIPTION
Update the GitHub Actions workflow to build and push a Docker image to Docker Hub instead of direct SSH deployment. Also add docker-compose.yaml for container orchestration with Watchtower for auto-updates.